### PR TITLE
Fixed issue with run.sh. Use binary path ./bin/api rather than ./cmd/…

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,4 +8,4 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 # Run api binary
-sudo ./cmd/bin/api
+sudo ./bin/api


### PR DESCRIPTION
Fixed issue with run.sh. Use binary path ./bin/api rather than ./cmd/bin/api.